### PR TITLE
Fix for OUJS

### DIFF
--- a/CopyPasteBin/CopyPasteBin.user.js
+++ b/CopyPasteBin/CopyPasteBin.user.js
@@ -5,7 +5,7 @@
 // @description  Copy content of a PasteBin snippet with a single click
 // @author       Peter Badida
 // @copyright    2017+, Peter Badida
-// @license      GNU GPLv3
+// @license      GPL-3.0
 // @homepage     https://github.com/KeyWeeUsr/Userscripts/tree/master/CopyPasteBin
 // @supportURL   https://github.com/KeyWeeUsr/Userscripts/issues
 // @icon         https://pastebin.com/favicon.ico


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify all of your affected scripts that utilize GPL for the License Type. The change is syntactically equivalent.

Until this change is made you will be unable to update those affected scripts.

Thanks,
OUJS Staff