### PR TITLE
Fix for OUJS

### DIFF
--- a/TopRepos/TopRepos.user.js
+++ b/TopRepos/TopRepos.user.js
@@ -5,7 +5,7 @@
 // @description  Show star-ordered user's repositories in "Popular repositories"
 // @author       Peter Badida
 // @copyright    2016+, Peter Badida
-// @license      GNU GPLv3
+// @license      GPL-3.0
 // @homepage     https://github.com/KeyWeeUsr/Userscripts/tree/master/TopRepos
 // @supportURL   https://github.com/KeyWeeUsr/Userscripts/issues
 // @icon         https://assets-cdn.github.com/favicon.ico


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify all of your affected scripts that utilize GPL for the License Type. The change is syntactically equivalent.

Until this change is made you will be unable to update those affected scripts.

Thanks,
OUJS Staff